### PR TITLE
fix(export): ensure save dialogs use explicit file extensions

### DIFF
--- a/src/main/UIGFJson.js
+++ b/src/main/UIGFJson.js
@@ -70,7 +70,7 @@ const exportUIGF = async (uids) => {
     result.hkrpg.push(dataTemp)
   })
   const filePath = dialog.showSaveDialogSync({
-    defaultPath: path.join(app.getPath('downloads'), fulldata.length > 1 ? `UIGF_${getTimeString()}` : `UIGF_${fulldata[0].uid}_${getTimeString()}`),
+    defaultPath: path.join(app.getPath('downloads'), fulldata.length > 1 ? `UIGF_${getTimeString()}.json` : `UIGF_${fulldata[0].uid}_${getTimeString()}.json`),
     filters: [
       { name: i18n.uigf.fileType, extensions: ['json'] }
     ]

--- a/src/main/excel.js
+++ b/src/main/excel.js
@@ -152,7 +152,7 @@ const start = async () => {
 
   const buffer = await workbook.xlsx.writeBuffer()
   const filePath = dialog.showSaveDialogSync({
-    defaultPath: path.join(app.getPath('downloads'), `${filePrefix}_${getTimeString()}`),
+    defaultPath: path.join(app.getPath('downloads'), `${filePrefix}_${getTimeString()}.xlsx`),
     filters: [
       { name: fileType, extensions: ['xlsx'] }
     ]


### PR DESCRIPTION
This pull request makes small changes to the file export dialogs in both `UIGFJson.js` and `excel.js`. The main improvement is that the suggested default filenames now include the appropriate file extensions (`.json` and `.xlsx`), which helps users save files with the correct format.

File dialog improvements:

* Added `.json` extension to the default export filename in `src/main/UIGFJson.js` for UIGF exports.
* Added `.xlsx` extension to the default export filename in `src/main/excel.js` for Excel exports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * UIGF JSON exports now consistently append the .json extension to all exported filenames, ensuring uniform file naming across different export types
  * Excel exports now properly include the .xlsx extension in default filenames, providing clearer file type identification during save operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->