### PR TITLE
fix: preserve configured language for fetches

### DIFF
--- a/src/main/getData.js
+++ b/src/main/getData.js
@@ -844,7 +844,7 @@ ipcMain.handle("FETCH_DATA", async (event, arg) => {
 });
 
 ipcMain.handle("I18N_DATA", () => {
-    return i18n.data;
+    return { ...i18n.data, lang: config.lang };
 });
 
 ipcMain.handle("LANG_MAP", () => {


### PR DESCRIPTION
## Summary

- 修正抽卡資料抓取時 fallback 到 `zh-cn` 的問題，改為使用目前設定的語言
- 避免新保存的 `endfield-list-*.json` 中 `poolName` 語言與設定不一致，導致 `抽卡詳情` 頁面顯示錯誤語言
- 不處理既有已保存資料的語言遷移